### PR TITLE
Use wildcards for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,26 +19,13 @@ script:
 - make go:test
 - make go:lint
 - make go:build-all
+- ls -l release/
 
 deploy:
   provider: releases
-  api_key: $GITHUB_OAUTH_TOKEN
-  file:
-    - release/$APP_darwin_386
-    - release/$APP_darwin_amd64
-    - release/$APP_freebsd_386
-    - release/$APP_freebsd_amd64
-    - release/$APP_freebsd_arm
-    - release/$APP_linux_386
-    - release/$APP_linux_amd64
-    - release/$APP_linux_arm
-    - release/$APP_netbsd_386
-    - release/$APP_netbsd_amd64
-    - release/$APP_netbsd_arm
-    - release/$APP_openbsd_386
-    - release/$APP_openbsd_amd64
-    - release/$APP_windows_386.exe
-    - release/$APP_windows_amd64.exe
+  api_key: "$GITHUB_API_KEY"
+  file_glob: true
+  file: "release/*"
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
## what
* use a wildcard for travis release
* rename `GITHUB_OAUTH_TOKEN` to `GITHUB_API_KEY` for correctness

## why
* easier to maintain

## who
@goruha 