### PR TITLE
Inherit parent environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ COPYRIGHT_SOFTWARE_DESCRIPTION:=Sudo Shell provides a login shell that can be us
 PATH:=$(PATH):$(GOPATH)/bin
 
 include $(shell curl --silent -O "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo Makefile.build-harness)
-- make travis:docker-tag-and-push
 
 setup:
 	make init go:deps-build go:deps-dev go:deps go:lint 
 
 build:
 	make go:build
+
+install:
+	install -m 0755 release/sudosh /usr/local/bin/sudosh

--- a/main.go
+++ b/main.go
@@ -59,10 +59,10 @@ func main() {
 	}
 
 	// Prepare `sudo` args
-	if len(os.Args) <= 2 {
-		args = []string{"sudo", "-u", user.Username, "-s", shell, "-l"}
+	if len(os.Args) < 2 {
+		args = []string{"sudo", "-E", "-u", user.Username, "--", shell, "-l"}
 	} else {
-		args = append([]string{"sudo", "-u", user.Username, "--"}, os.Args[1:]...)
+		args = append([]string{"sudo", "-E", "-u", user.Username, "-s", shell, "-c", "--"}, os.Args[1:]...)
 	}
 
 	execErr := syscall.Exec(binary, args, env)

--- a/main.go
+++ b/main.go
@@ -53,9 +53,9 @@ func main() {
 	env := os.Environ()
 
 	// Lookup path for `sudo`
-	binary, lookPathErr := exec.LookPath("sudo")
-	if lookPathErr != nil {
-		log.Fatalf("error: find to find sudo: %v", lookPathErr)
+	binary, sudoPathErr := exec.LookPath("sudo")
+	if sudoPathErr != nil {
+		log.Fatalf("error: find to find sudo: %v", sudoPathErr)
 	}
 
 	// Prepare `sudo` args


### PR DESCRIPTION
## what
* inherit parent environment
* use default shell to execute shell commands

## why
* parent env is rather important because without it, ssh agent forwarding is impossible (e.g. `SSH_AGENT_SOCK`)

## who
@cloudposse/engineering 