### PR TITLE
Avoid recursive shells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.build-harness
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COPYRIGHT_SOFTWARE_DESCRIPTION:=Sudo Shell provides a login shell that can be us
 
 PATH:=$(PATH):$(GOPATH)/bin
 
-include $(shell curl --silent -O "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo Makefile.build-harness)
+include $(shell curl --silent -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
 
 setup:
 	make init go:deps-build go:deps-dev go:deps go:lint 

--- a/main.go
+++ b/main.go
@@ -77,6 +77,9 @@ func main() {
 		log.Fatalf("error: unable to determine current user: %v", userErr)
 	}
 
+	// Set default shell (do not set to `sudosh`; it may cause infinite loops)
+	os.Setenv("SHELL", shell)
+
 	// Fetch environment
 	env := os.Environ()
 
@@ -88,9 +91,9 @@ func main() {
 
 	// Prepare `sudo` args
 	if len(os.Args) < 2 {
-		args = []string{"sudo", "-E", "-u", username, "--", shell, "-l"}
+		args = []string{"sudo", "-E", "-u", username, shell, "-l"}
 	} else {
-		args = append([]string{"sudo", "-E", "-u", username, "-s", shell, "-c", "--"}, os.Args[1:]...)
+		args = append([]string{"sudo", "-E", "-u", username, shell}, os.Args[1:]...)
 	}
 
 	execErr := syscall.Exec(binary, args, env)


### PR DESCRIPTION
## what
* Export `SHELL` to match the *desired* shell, rather than the current `sudosh` shell
* Do not use `-s` as it causes an unnecessary subshell
* Emulate more closely the behavior of the desired shell (which is why we dropped the `--`)

## why
* When `SHELL` was set to the current `sudosh` wrapper shell, it would cause infinite loops for non-login shells (E.g. where a command was passed via `ssh`)
* Better compatibility with system login shells

## who
@goruha 