### PR TITLE
Add one more fallback to LOGNAME env

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,11 @@ func main() {
 		username = user.Username
 	}
 
+	// Fallback to fetching the `LOGNAME` env
+	if username == "" {
+		username = os.Getenv("LOGNAME")
+	}
+
 	// Fallback to fetching the `USER` env
 	if username == "" {
 		username = os.Getenv("USER")


### PR DESCRIPTION
LOGNAME is a very old env var very similar to USER.
Back in days some Unix-like systems preferred LOGNAME, some USER env var.
Currently both USER and LOGNAME are set for backward compatibility on all systems I know.
But there may be exceptions.
https://lists.ubuntu.com/archives/ubuntu-users/2015-July/281503.html
https://help.ubuntu.com/community/EnvironmentVariables