### PR TITLE
feat(M1 support): Create binary compatible for M1 (ARM) Macs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,7 @@ jobs:
             linux/arm
             darwin/386
             darwin/amd64
+            darwin/arm64
             linux/386
             linux/amd64
             freebsd/amd64


### PR DESCRIPTION
## What
* added OS and ARCH pair to enable M1 compatible binary releases

## Why
* new arm architecture based Macs can run sudosh